### PR TITLE
Fixes the warnings related to the linkage

### DIFF
--- a/Sponge.c
+++ b/Sponge.c
@@ -33,7 +33,7 @@ void printArray(unsigned char *array, unsigned int size, char *name) {
  * 
  * @param state         The 1024-bit array to be initialized
  */
-void inline initState(uint64_t state[/*16*/]){
+void initState(uint64_t state[/*16*/]){
     memset(state, 0,            BLOCK_LEN_BYTES);
     memcpy(state + BLOCK_LEN_INT64, blake2b_IV,   BLOCK_LEN_BYTES);
 }


### PR DESCRIPTION
To reproduce the issue just run:

```
  ~/h/o/a/Lyra git:master ❯❯❯ make
  cc Lyra.c Sponge.c Main.c -o Lyra -std=c99 -Wall -pedantic -O3 -lm
  Sponge.c:38:37: warning: static variable 'blake2b_IV' is used in an inline function with external linkage [-Wstatic-in-inline]
      memcpy(state + BLOCK_LEN_INT64, blake2b_IV,   BLOCK_LEN_BYTES);
                                      ^
  /usr/include/secure/_string.h:65:33: note: expanded from macro 'memcpy'
    __builtin___memcpy_chk (dest, src, len, __darwin_obsz0 (dest))
                                  ^
  ./Sponge.h:60:1: note: use 'static' to give inline function 'initState' internal linkage
  void initState(uint64_t state[/*16*/]);
  ^
  static
  ./Sponge.h:22:23: note: 'blake2b_IV' declared here
  static const uint64_t blake2b_IV[8] =
```

I hope it helps
